### PR TITLE
Fix inaccurate wheel tag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,6 @@ replace = version='{new_version}'
 search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
 
-[bdist_wheel]
-universal = 1
-
 [flake8]
 exclude = docs
 


### PR DESCRIPTION
Remove `universal=1` option, from `bdist_wheel` options.
When enabled, it produces incorrect `py2.py3` wheel distribution tag.

Incorrect: `ansible_events-0.4.0-py2.py3-none-any.whl`
Correct:   `ansible_events-0.4.0-py3-none-any.whl`