### PR TITLE
fix tox configuration to support PEP 517 build-backend

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py39, flake8
+isolated_build = True
 
 [travis]
 python =


### PR DESCRIPTION
Tox requires an isolated build to use PEP 517 build-backend