### PR TITLE
Fix documentation issues

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ release = ansible_events.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 Welcome to ansible-events's documentation!
-======================================
+==========================================
 
 .. toctree::
    :maxdepth: 2
@@ -8,7 +8,6 @@ Welcome to ansible-events's documentation!
    readme
    installation
    usage
-   modules
    contributing
    authors
    history


### PR DESCRIPTION
Fix warnings:

    WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid langauge code. Falling back to 'en' (English).

    docs/index.rst:2: WARNING: Title underline too short.

    Welcome to ansible-events's documentation!
    ======================================

    docs/index.rst:4: WARNING: toctree contains reference to nonexisting document 'modules'