### PR TITLE
Install flake8-bugbear plugin

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install dependencies
-        run: python -m pip install flake8
+        run: python -m pip install -r requirements_lint.txt
       - name: Lint with flake8
         run: flake8 . --count --show-source --statistics
 

--- a/ansible_events/event_filters/json_filter.py
+++ b/ansible_events/event_filters/json_filter.py
@@ -30,8 +30,9 @@ def matches_exclude_keys(exclude_keys, s):
     return False
 
 
-# FIXME(cutwater): Mutable instances are used as a default value of a function.
-def main(event, exclude_keys=[], include_keys=[]):
+def main(event, exclude_keys=None, include_keys=None):
+    exclude_keys = exclude_keys or []
+    include_keys = include_keys or []
     q = []
     q.append(event)
     while q:

--- a/ansible_events/inventory.py
+++ b/ansible_events/inventory.py
@@ -15,7 +15,7 @@ def matches_host(subpattern, host):
 def matching_hosts(inventory, pattern):
     subpatterns = parse_inventory_pattern(pattern)
     hosts = []
-    for groupname, group in inventory.items():
+    for group in inventory.values():
         for host in group.get("hosts").keys():
             for sp in subpatterns:
                 if matches_host(sp, host):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 -r requirements_test.txt
+-r requirements_lint.txt
 
 bump2version
 
@@ -9,11 +10,6 @@ build
 # Testing
 tox
 coverage
-
-# Linters
-flake8
-black
-isort
 
 # Docs
 Sphinx

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,0 +1,4 @@
+flake8
+flake8-bugbear
+isort
+black

--- a/tests/event_filters/json_filter.py
+++ b/tests/event_filters/json_filter.py
@@ -30,8 +30,9 @@ def matches_exclude_keys(exclude_keys, s):
     return False
 
 
-# FIXME(cutwater): Mutable instances are used as a default value of a function.
-def main(event, exclude_keys=[], include_keys=[]):
+def main(event, exclude_keys=None, include_keys=None):
+    exclude_keys = exclude_keys or []
+    include_keys = include_keys or []
     q = []
     q.append(event)
     while q:

--- a/tests/sources/log_scraper.py
+++ b/tests/sources/log_scraper.py
@@ -12,7 +12,7 @@ def main(queue, args):
     }
     log_file_locs = {log_file: 0 for log_file in log_file_patterns}
 
-    for log_file, loc in log_file_locs.items():
+    for log_file in log_file_locs:
         with open(log_file) as f:
             f.seek(0, os.SEEK_END)
             log_file_locs[log_file] = f.tell()


### PR DESCRIPTION
Fix warnings introduced by installing new flake8 plugin.

Warnings:

```
./tests/sources/log_scraper.py:15:19: B007 Loop control variable 'loc' not used within the loop body.
    If this is intended, start the name with an underscore.
./tests/event_filters/json_filter.py:34:30: B006 Do not use mutable data structures for argument defaults.
    They are created during function definition time.
    All calls to the function reuse this one instance of that data structure, persisting changes between them.
./tests/event_filters/json_filter.py:34:47: B006 Do not use mutable data structures for argument defaults.
    They are created during function definition time.
    All calls to the function reuse this one instance of that data structure, persisting changes between them.
./ansible_events/inventory.py:18:9: B007 Loop control variable 'groupname' not used within the loop body.
    If this is intended, start the name with an underscore.
./ansible_events/event_filters/json_filter.py:34:30: B006 Do not use mutable data structures for argument defaults.
./ansible_events/event_filters/json_filter.py:34:47: B006 Do not use mutable data structures for argument defaults.
```