### PR TITLE
add json_mode option for run_playbook action

### DIFF
--- a/ansible_events/builtin.py
+++ b/ansible_events/builtin.py
@@ -124,6 +124,7 @@ async def run_playbook(
     verbosity: int = 0,
     var_root: Optional[str] = None,
     copy_files: Optional[bool] = False,
+    json_mode: Optional[bool] = False,
     **kwargs,
 ):
     logger = logging.getLogger()
@@ -190,6 +191,7 @@ async def run_playbook(
             limit=host_limit,
             verbosity=verbosity,
             event_handler=event_callback,
+            json_mode=json_mode,
         ),
     )
 

--- a/schema/ruleset_schema.json
+++ b/schema/ruleset_schema.json
@@ -102,7 +102,8 @@
                         "post_events": { "type": "boolean" },
                         "assert_facts": { "type": "boolean" },
                         "verbosity": {"type": "integer" },
-                        "var_root": {"type": "string" }
+                        "var_root": {"type": "string" },
+                        "json_mode": { "type": "boolean" }
                     },
                     "required": [
                         "name"


### PR DESCRIPTION
Be able to produce the output from ansible-runner with json format. In addition to the feature, which can be requested by users, I will need it for black box testing of the CLI. 
