### PR TITLE
Support events in print_event

### DIFF
--- a/ansible_events/builtin.py
+++ b/ansible_events/builtin.py
@@ -62,10 +62,13 @@ async def print_event(
     print_fn: Callable = print
     if pretty:
         print_fn = pprint
+    var_name = 'event'
+    if 'events' in variables:
+      var_name = 'events'
     if var_root:
-        print_fn(dpath.util.get(variables["event"], var_root, separator="."))
+        print_fn(dpath.util.get(variables[var_name], var_root, separator="."))
     else:
-        print_fn(variables["event"])
+        print_fn(variables[var_name])
     sys.stdout.flush()
     await event_log.put(dict(type="Action", action="print_event"))
 

--- a/ansible_events/builtin.py
+++ b/ansible_events/builtin.py
@@ -62,9 +62,9 @@ async def print_event(
     print_fn: Callable = print
     if pretty:
         print_fn = pprint
-    var_name = 'event'
-    if 'events' in variables:
-      var_name = 'events'
+    var_name = "event"
+    if "events" in variables:
+        var_name = "events"
     if var_root:
         print_fn(dpath.util.get(variables[var_name], var_root, separator="."))
     else:

--- a/tests/examples/22_print_events.yml
+++ b/tests/examples/22_print_events.yml
@@ -1,0 +1,15 @@
+---
+- name: 22 Print events
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name:
+      condition: 
+        all:
+          - event.i == 1
+          - event.i == 2
+      action:
+        print_event:

--- a/tests/examples/26_print_events.yml
+++ b/tests/examples/26_print_events.yml
@@ -1,5 +1,5 @@
 ---
-- name: 22 Print events
+- name: 26 Print events
   hosts: all
   sources:
     - name: range

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -649,3 +649,31 @@ async def test_25_max_attributes_nested():
     event = event_log.get_nowait()
     assert event["type"] == "Shutdown", "2"
     assert event_log.empty()
+
+
+@pytest.mark.asyncio
+async def test_26_print_events():
+    ruleset_queues, queue, event_log = load_rules(
+        "examples/26_print_events.yml"
+    )
+
+    queue.put_nowait(dict(i=1))
+    queue.put_nowait(dict(i=2))
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        dict(),
+    )
+
+    event_log.get_nowait()
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "print_event", "2"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "1"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "7"
+    assert event_log.empty()


### PR DESCRIPTION
The print_event action currently only supports a single event and fails when invoked with multiple events. This PR adds support for multiple events.

https://issues.redhat.com/browse/AAP-4829