### PR TITLE
add ansible as a required dependency

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,9 +2,6 @@ watchdog
 docopt
 psutil
 requests
-ansible
-ansible-core
-ansible-runner
 
 pytest
 pytest-asyncio

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     janus
     ansible-runner
     websockets
+    ansible
 
 [options.packages.find]
 include =


### PR DESCRIPTION
Add ansible as a required dependency: https://github.com/benthomasson/ansible-events/blob/main/ansible_events/collection.py#L17

Also removes ansible-runner from test-requirements (defined also as a required dependency) and ansible-core (installed by ansible)