### PR TITLE
Support var_root in multi events

### DIFF
--- a/ansible_events/builtin.py
+++ b/ansible_events/builtin.py
@@ -10,7 +10,7 @@ import tempfile
 import uuid
 from functools import partial
 from pprint import pprint
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Union
 
 import ansible_runner
 import dpath.util
@@ -56,16 +56,20 @@ async def print_event(
     variables: Dict,
     facts: Dict,
     ruleset: str,
-    var_root: Optional[str] = None,
+    var_root: Optional[Union[str, List[str]]] = None,
     pretty: Optional[str] = None,
 ):
     print_fn: Callable = print
     if pretty:
         print_fn = pprint
+
     if var_root:
-        print_fn(dpath.util.get(variables["event"], var_root, separator="."))
-    else:
+        update_variables(variables, var_root)
+
+    if "event" in variables:
         print_fn(variables["event"])
+    elif "events" in variables:
+        print_fn(variables["events"])
     sys.stdout.flush()
     await event_log.put(dict(type="Action", action="print_event"))
 
@@ -122,7 +126,7 @@ async def run_playbook(
     assert_facts: Optional[bool] = None,
     post_events: Optional[bool] = None,
     verbosity: int = 0,
-    var_root: Optional[str] = None,
+    var_root: Optional[Union[str, List[str]]] = None,
     copy_files: Optional[bool] = False,
     json_mode: Optional[bool] = False,
     **kwargs,
@@ -137,8 +141,7 @@ async def run_playbook(
     variables["facts"] = facts
 
     if var_root:
-        o = dpath.util.get(variables["event"], var_root, separator=".")
-        variables["event"] = o
+        update_variables(variables, var_root)
 
     os.mkdir(os.path.join(temp, "env"))
     with open(os.path.join(temp, "env", "extravars"), "w") as f:
@@ -232,3 +235,24 @@ actions: Dict[str, Callable] = dict(
     run_playbook=run_playbook,
     shutdown=shutdown,
 )
+
+
+def update_variables(variables: Dict, var_root: Union[str, List[str]]):
+    var_roots = [var_root] if isinstance(var_root, str) else var_root
+    if "event" in variables:
+        for name in var_roots:
+            new_value = dpath.util.get(
+                variables["event"], name, separator=".", default=None
+            )
+            if new_value:
+                variables["event"] = new_value
+                break
+    elif "events" in variables:
+        for k, v in variables["events"].items():
+            for name in var_roots:
+                new_value = dpath.util.get(
+                    v, name, separator=".", default=None
+                )
+                if new_value:
+                    variables["events"][k] = new_value
+                    break

--- a/tests/examples/23_var_root.yml
+++ b/tests/examples/23_var_root.yml
@@ -1,0 +1,17 @@
+---
+- name: 23 multiple events all with var_root
+  hosts: all
+  sources:
+    - non_existent:
+  rules:
+    - name:
+      condition:
+        all:
+          - events.webhook << event.webhook.payload.url == "http://www.example.com"
+          - events.kafka << event.kafka.message.channel == "red"
+      action:
+        print_event:
+          var_root:
+            - webhook.payload
+            - kafka.message
+

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -563,3 +563,39 @@ async def test_21_run_playbook():
     event = event_log.get_nowait()
     assert event["type"] == "Shutdown", "8"
     assert event_log.empty()
+
+
+@pytest.mark.asyncio
+async def test_23_multiple_events_var_root():
+    ruleset_queues, queue, event_log = load_rules("examples/23_var_root.yml")
+
+    queue.put_nowait(
+        dict(
+            webhook=dict(
+                payload=dict(url="http://www.example.com", action="merge")
+            )
+        )
+    )
+    queue.put_nowait(
+        dict(kafka=dict(message=dict(topic="testing", channel="red")))
+    )
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        dict(),
+    )
+
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "0"
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "print_event", "2"
+
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "6"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "7"
+    assert event_log.empty()


### PR DESCRIPTION
var_root is used to optionally lift up the keys in a nested events
dictionary.
The var_root has been modified to take in a sigle nested key in the form
of a.b.c or or a list of keys of the form
- a.b.c
- x.y.x

When we have matching on multiple events from different sources the
event payload could have different keys. The var_root can store the
nested keyname for different payloads and pick them from different
events.

If the var_root has the following keys
   ['webhook.payload', 'kafka.message']

it can modify the events from

{'events': {'webhook': {'webhook': {'payload': {'url': 'http://www.example.com', 'action': 'merge'}}},
            'kafka': {'kafka': {'message': {'topic': 'testing', 'channel': 'red'}}}}

to

{'events': {'webhook': {'url': 'http://www.example.com', 'action': 'merge'},
            'kafka': {'topic': 'testing', 'channel': 'red'}}