### PR TITLE
Raise exception if a playbook fails execution

### DIFF
--- a/ansible_events/builtin.py
+++ b/ansible_events/builtin.py
@@ -125,6 +125,7 @@ async def run_playbook(
     var_root: Optional[str] = None,
     copy_files: Optional[bool] = False,
     json_mode: Optional[bool] = False,
+    ignore_errors: Optional[bool] = False,
     **kwargs,
 ):
     logger = logging.getLogger()
@@ -204,6 +205,11 @@ async def run_playbook(
     ):
         with open(status_file, "r") as f:
             status = f.read()
+
+    if rc != 0 and not ignore_errors:
+        raise Exception(
+            f"Playbook {name} failed execution rc:{rc} status:{status}"
+        )
 
     if assert_facts or post_events:
         logger.debug("assert_facts")

--- a/schema/ruleset_schema.json
+++ b/schema/ruleset_schema.json
@@ -103,7 +103,8 @@
                         "assert_facts": { "type": "boolean" },
                         "verbosity": {"type": "integer" },
                         "var_root": {"type": "string" },
-                        "json_mode": { "type": "boolean" }
+                        "json_mode": { "type": "boolean" },
+                        "ignore_errors": { "type": "boolean" }
                     },
                     "required": [
                         "name"

--- a/tests/fail_playbook.yml
+++ b/tests/fail_playbook.yml
@@ -1,0 +1,9 @@
+---
+- name: A playbook that always fails
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name:
+      ansible.builtin.fail:
+        msg: 'Intentionally failing test'
+      when: 1 != 0

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -64,7 +64,7 @@ async def test_run_rulesets():
         event_log,
         ruleset_queues,
         dict(),
-        dict(),
+        load_inventory('inventory.yml'),
     )
 
     assert event_log.get_nowait()["type"] == "EmptyEvent", "0"
@@ -72,11 +72,9 @@ async def test_run_rulesets():
     assert event_log.get_nowait()["type"] == "Action", "0.2"
     assert event_log.get_nowait()["type"] == "ProcessedEvent", "1"
     assert event_log.get_nowait()["type"] == "Job", "1.0"
-    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.1"
-    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.2"
-    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.3"
-    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.4"
-    assert event_log.get_nowait()["type"] == "Action", "1.5"
+    for i in range(9):
+       assert event_log.get_nowait()["type"] == "AnsibleEvent", f"1.{i}"
+    assert event_log.get_nowait()["type"] == "Action", "1.9"
     assert event_log.get_nowait()["type"] == "ProcessedEvent", "2"
     assert event_log.get_nowait()["type"] == "Action", "2.1"
     assert event_log.get_nowait()["type"] == "ProcessedEvent", "3"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -64,7 +64,7 @@ async def test_run_rulesets():
         event_log,
         ruleset_queues,
         dict(),
-        load_inventory('inventory.yml'),
+        load_inventory("inventory.yml"),
     )
 
     assert event_log.get_nowait()["type"] == "EmptyEvent", "0"
@@ -73,7 +73,7 @@ async def test_run_rulesets():
     assert event_log.get_nowait()["type"] == "ProcessedEvent", "1"
     assert event_log.get_nowait()["type"] == "Job", "1.0"
     for i in range(9):
-       assert event_log.get_nowait()["type"] == "AnsibleEvent", f"1.{i}"
+        assert event_log.get_nowait()["type"] == "AnsibleEvent", f"1.{i}"
     assert event_log.get_nowait()["type"] == "Action", "1.9"
     assert event_log.get_nowait()["type"] == "ProcessedEvent", "2"
     assert event_log.get_nowait()["type"] == "Action", "2.1"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -341,7 +341,7 @@ async def test_run_rulesets_on_hosts():
         event_log,
         ruleset_queues,
         dict(),
-        dict(),
+        load_inventory("inventory1.yml"),
     )
 
     assert event_log.get_nowait()["type"] == "EmptyEvent", "0"
@@ -351,7 +351,14 @@ async def test_run_rulesets_on_hosts():
     assert event_log.get_nowait()["type"] == "Job", "1.0"
     assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.1"
     assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.2"
-    assert event_log.get_nowait()["type"] == "Action", "1.3"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.3"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.4"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.4"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.5"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.6"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.7"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.8"
+    assert event_log.get_nowait()["type"] == "Action", "1.9"
     assert event_log.get_nowait()["type"] == "ProcessedEvent", "2"
     assert event_log.get_nowait()["type"] == "Action", "2.1"
     assert event_log.get_nowait()["type"] == "ProcessedEvent", "3"
@@ -403,5 +410,73 @@ async def test_run_assert_facts():
     assert event["status"] == "successful", "2.4"
 
     assert event_log.get_nowait()["type"] == "ProcessedEvent", "3"
+    assert event_log.get_nowait()["type"] == "Shutdown", "4"
+    assert event_log.empty()
+
+
+@pytest.mark.asyncio
+async def test_run_fail_playbook():
+    ruleset_queues, queue, event_log = load_rules(
+        "test_rules_fail_playbook.yml"
+    )
+    inventory = dict(
+        all=dict(hosts=dict(localhost=dict(ansible_connection="local")))
+    )
+    queue.put_nowait(dict())
+    queue.put_nowait(dict(i=1, meta=dict(hosts="localhost")))
+    queue.put_nowait(Shutdown())
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        inventory,
+    )
+
+    assert event_log.get_nowait()["type"] == "EmptyEvent", "0"
+    assert event_log.get_nowait()["type"] == "Job", "1.0"
+    for i in range(6):
+        assert event_log.get_nowait()["type"] == "AnsibleEvent", f"1.{i}"
+
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "2.1"
+    assert event["action"] == "run_playbook", "2.2"
+    assert event["rc"] == 2, "2.3"
+    assert event["status"] == "failed", "2.4"
+
+    assert event_log.get_nowait()["type"] == "ProcessedEvent", "3"
+    assert event_log.get_nowait()["type"] == "Shutdown", "4"
+    assert event_log.empty()
+
+
+@pytest.mark.asyncio
+async def test_run_exception_playbook():
+    ruleset_queues, queue, event_log = load_rules(
+        "test_rules_exception_playbook.yml"
+    )
+    inventory = dict(
+        all=dict(hosts=dict(localhost=dict(ansible_connection="local")))
+    )
+    queue.put_nowait(dict())
+    queue.put_nowait(dict(i=1, meta=dict(hosts="localhost")))
+    queue.put_nowait(Shutdown())
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        inventory,
+    )
+
+    assert event_log.get_nowait()["type"] == "EmptyEvent", "0"
+    assert event_log.get_nowait()["type"] == "Job", "1.0"
+    for i in range(6):
+        assert event_log.get_nowait()["type"] == "AnsibleEvent", f"1.{i}"
+
+    event = event_log.get_nowait()
+
+    assert event["type"] == "ProcessedEvent", "3"
+    assert (
+        str(event["results"][0]["error"])
+        == "Playbook fail_playbook.yml failed execution rc:2 status:failed"
+    ), "3.1"
     assert event_log.get_nowait()["type"] == "Shutdown", "4"
     assert event_log.empty()

--- a/tests/test_host_rules.yml
+++ b/tests/test_host_rules.yml
@@ -17,7 +17,7 @@
       condition: event.i == 2
       action:
         run_playbook:
-          name: hello_playbook.yml
+          name: hello_playbook1.yml
     - name:
       condition: event.i == 3
       action:

--- a/tests/test_rules_exception_playbook.yml
+++ b/tests/test_rules_exception_playbook.yml
@@ -1,0 +1,13 @@
+---
+- name: raise exception after running a playbook fails
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name:
+      condition: event.i == 1
+      action:
+        run_playbook:
+          name: fail_playbook.yml

--- a/tests/test_rules_fail_playbook.yml
+++ b/tests/test_rules_fail_playbook.yml
@@ -1,0 +1,14 @@
+---
+- name: fail running a playbook
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name:
+      condition: event.i == 1
+      action:
+        run_playbook:
+          name: fail_playbook.yml
+          ignore_errors: True


### PR DESCRIPTION
1. A user can supress the exception by setting ignore_errors
2. Fixed tests where the playbook was failing during execution
3. Added tests for ignore_errors