### PR TITLE
Fixed package name imports

### DIFF
--- a/ansible_events/builtin.py
+++ b/ansible_events/builtin.py
@@ -14,8 +14,8 @@ from typing import Callable, Dict, List, Optional
 
 import ansible_runner
 import dpath.util
-import durable.lang
 import yaml
+from durable import lang
 
 from .collection import find_playbook, has_playbook, split_collection_name
 from .conf import settings
@@ -37,10 +37,10 @@ async def none(
 async def debug(event_log, **kwargs):
     print(get_horizontal_rule("="))
     print("context:")
-    pprint(durable.lang.c.__dict__)
+    pprint(lang.c.__dict__)
     print(get_horizontal_rule("="))
     print("facts:")
-    pprint(durable.lang.get_facts(kwargs["ruleset"]))
+    pprint(lang.get_facts(kwargs["ruleset"]))
     print(get_horizontal_rule("="))
     print("kwargs:")
     pprint(kwargs)
@@ -81,7 +81,7 @@ async def assert_fact(
 ):
     logger = logging.getLogger()
     logger.debug(f"assert_fact {ruleset} {fact}")
-    durable.lang.assert_fact(ruleset, fact)
+    lang.assert_fact(ruleset, fact)
     await event_log.put(dict(type="Action", action="assert_fact"))
 
 
@@ -94,7 +94,7 @@ async def retract_fact(
     ruleset: str,
     fact: Dict,
 ):
-    durable.lang.retract_fact(ruleset, fact)
+    lang.retract_fact(ruleset, fact)
     await event_log.put(dict(type="Action", action="retract_fact"))
 
 
@@ -107,7 +107,7 @@ async def post_event(
     ruleset: str,
     event: Dict,
 ):
-    durable.lang.post(ruleset, event)
+    lang.post(ruleset, event)
     await event_log.put(dict(type="Action", action="post_event"))
 
 
@@ -214,9 +214,9 @@ async def run_playbook(
                 fact = json.loads(f.read())
             logger.debug(f"fact {fact}")
             if assert_facts:
-                durable.lang.assert_fact(ruleset, fact)
+                lang.assert_fact(ruleset, fact)
             if post_events:
-                durable.lang.post(ruleset, fact)
+                lang.post(ruleset, fact)
     await event_log.put(
         dict(type="Action", action="run_playbook", rc=rc, status=status)
     )

--- a/ansible_events/engine.py
+++ b/ansible_events/engine.py
@@ -6,7 +6,7 @@ import traceback
 from pprint import pformat
 from typing import Any, Dict, List, Optional, cast
 
-import durable.lang
+from durable import engine, lang
 
 import ansible_events.rule_generator as rule_generator
 from ansible_events.builtin import actions as builtin_actions
@@ -186,8 +186,8 @@ async def call_action(
             }
             logger.info(action_args)
             if facts is None:
-                facts = durable.lang.get_facts(ruleset)
-            logger.info(f"facts: {durable.lang.get_facts(ruleset)}")
+                facts = lang.get_facts(ruleset)
+            logger.info(f"facts: {lang.get_facts(ruleset)}")
             if "ruleset" not in action_args:
                 action_args["ruleset"] = ruleset
             result = await builtin_actions[action](
@@ -201,10 +201,10 @@ async def call_action(
         except KeyError as e:
             logger.error(f"{e}\n{pformat(variables_copy)}")
             raise
-        except durable.engine.MessageNotHandledException as e:
+        except engine.MessageNotHandledException as e:
             logger.error(f"MessageNotHandledException: {action_args}")
             result = dict(error=e)
-        except durable.engine.MessageObservedException as e:
+        except engine.MessageObservedException as e:
             logger.info(f"MessageObservedException: {action_args}")
             result = dict(error=e)
         except ShutdownException:
@@ -234,9 +234,7 @@ async def run_rulesets(
     logger.info("run_ruleset")
 
     if redis_host_name and redis_port:
-        provide_durability(
-            durable.lang.get_host(), redis_host_name, redis_port
-        )
+        provide_durability(lang.get_host(), redis_host_name, redis_port)
 
     ansible_ruleset_queue_plans = [
         RuleSetQueuePlan(ruleset, queue, asyncio.Queue())
@@ -279,13 +277,13 @@ async def run_rulesets(
                 logger.info("Asserting event")
                 try:
                     logger.debug(data)
-                    durable.lang.post(ruleset.name, data)
-                except durable.engine.MessageObservedException:
+                    lang.post(ruleset.name, data)
+                except engine.MessageObservedException:
                     logger.debug(f"MessageObservedException: {data}")
-                except durable.engine.MessageNotHandledException:
+                except engine.MessageNotHandledException:
                     logger.debug(f"MessageNotHandledException: {data}")
                 finally:
-                    logger.debug(durable.lang.get_pending_events(ruleset.name))
+                    logger.debug(lang.get_pending_events(ruleset.name))
                 while not plan.empty():
                     item = cast(ActionContext, await plan.get())
                     logger.debug(item)
@@ -295,7 +293,7 @@ async def run_rulesets(
                 await event_log.put(
                     dict(type="ProcessedEvent", results=results)
                 )
-            except durable.engine.MessageNotHandledException:
+            except engine.MessageNotHandledException:
                 logger.info(f"MessageNotHandledException: {data}")
                 await event_log.put(dict(type="MessageNotHandled"))
             except ShutdownException:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -2,9 +2,9 @@ import asyncio
 import os
 from queue import Queue
 
-import durable.lang
 import pytest
 import yaml
+from durable import lang
 from durable.lang import assert_fact, c, m, post, rule, ruleset, when_all
 
 from ansible_events.rule_generator import generate_rulesets
@@ -67,15 +67,15 @@ def test_ruleset():
     some_rules = ruleset("test_rules")
 
     assert some_rules
-    assert durable.lang._rulesets
-    assert durable.lang._rulesets["test_rules"] == some_rules
+    assert lang._rulesets
+    assert lang._rulesets["test_rules"] == some_rules
 
-    assert len(durable.lang._ruleset_stack) == 0
+    assert len(lang._ruleset_stack) == 0
 
     with some_rules:
-        assert durable.lang._ruleset_stack[-1] == some_rules
+        assert lang._ruleset_stack[-1] == some_rules
 
-    assert len(durable.lang._ruleset_stack) == 0
+    assert len(lang._ruleset_stack) == 0
 
     assert some_rules.define() == ("test_rules", {})
 
@@ -85,13 +85,13 @@ def test_rules():
     some_rules = ruleset("test_rules1")
 
     assert some_rules
-    assert durable.lang._rulesets
-    assert durable.lang._rulesets["test_rules1"] == some_rules
+    assert lang._rulesets
+    assert lang._rulesets["test_rules1"] == some_rules
 
-    assert len(durable.lang._ruleset_stack) == 0
+    assert len(lang._ruleset_stack) == 0
 
     with some_rules:
-        assert durable.lang._ruleset_stack[-1] == some_rules
+        assert lang._ruleset_stack[-1] == some_rules
 
         def x(c):
             print("c")
@@ -99,7 +99,7 @@ def test_rules():
         # when_all(m.x == 5)(x)
         rule("all", True, m.x == 5)(x)
 
-    assert len(durable.lang._ruleset_stack) == 0
+    assert len(lang._ruleset_stack) == 0
 
     assert some_rules.define() == (
         "test_rules1",


### PR DESCRIPTION
This would help us when we switch to drools.
Places where we call durable.lang have been changed to lang