### PR TITLE
Support var_root in multi events - 2

### DIFF
--- a/ansible_events/builtin.py
+++ b/ansible_events/builtin.py
@@ -56,7 +56,7 @@ async def print_event(
     variables: Dict,
     facts: Dict,
     ruleset: str,
-    var_root: Union[str, List[str], None] = None,
+    var_root: Union[str, Dict, None] = None,
     pretty: Optional[str] = None,
 ):
     print_fn: Callable = print
@@ -127,7 +127,7 @@ async def run_playbook(
     assert_facts: Optional[bool] = None,
     post_events: Optional[bool] = None,
     verbosity: int = 0,
-    var_root: Union[str, List[str], None] = None,
+    var_root: Union[str, Dict, None] = None,
     copy_files: Optional[bool] = False,
     json_mode: Optional[bool] = False,
     **kwargs,
@@ -252,22 +252,22 @@ actions: Dict[str, Callable] = dict(
 )
 
 
-def update_variables(variables: Dict, var_root: Union[str, List[str]]):
-    var_roots = [var_root] if isinstance(var_root, str) else var_root
+def update_variables(variables: Dict, var_root: Union[str, Dict]):
+    var_roots = {var_root: var_root} if isinstance(var_root, str) else var_root
     if "event" in variables:
-        for name in var_roots:
+        for key, _new_key in var_roots.items():
             new_value = dpath.util.get(
-                variables["event"], name, separator=".", default=None
+                variables["event"], key, separator=".", default=None
             )
             if new_value:
                 variables["event"] = new_value
                 break
     elif "events" in variables:
-        for k, v in variables["events"].items():
-            for name in var_roots:
+        for _k, v in variables["events"].items():
+            for old_key, new_key in var_roots.items():
                 new_value = dpath.util.get(
-                    v, name, separator=".", default=None
+                    v, old_key, separator=".", default=None
                 )
                 if new_value:
-                    variables["events"][k] = new_value
+                    variables["events"][new_key] = new_value
                     break

--- a/tests/examples/27_var_root.yml
+++ b/tests/examples/27_var_root.yml
@@ -1,0 +1,17 @@
+---
+- name: 27 multiple events all with var_root
+  hosts: all
+  sources:
+    - non_existent:
+  rules:
+    - name:
+      condition:
+        all:
+          - events.webhook << event.webhook.payload.url == "http://www.example.com"
+          - events.kafka << event.kafka.message.channel == "red"
+      action:
+        print_event:
+          var_root:
+            - webhook.payload
+            - kafka.message
+

--- a/tests/examples/27_var_root.yml
+++ b/tests/examples/27_var_root.yml
@@ -12,6 +12,6 @@
       action:
         print_event:
           var_root:
-            - webhook.payload
-            - kafka.message
+            webhook.payload: webhook
+            kafka.message: kafka
 


### PR DESCRIPTION
Redid https://github.com/benthomasson/ansible-events/pull/119

var_root is used to optionally lift up the keys in a nested events
dictionary.
The var_root has been modified to take in a sigle nested key in the form
of a.b.c or or a dictionary of the form old_key:new_key
var_root:
   a.b.c: c
   x.y.z: z

When we have matching on multiple events from different sources the
event payload could have different keys. The var_root can store the
nested keyname for different payloads and pick them from different
events.

If the var_root has the following dictionary
   {
    'webhook.payload': 'webhook', 
     'kafka.message':'kafka'
  }

it can modify the events from

{'events': {'m_0': {'webhook': {'payload': {'url': 'http://www.example.com', 'action': 'merge'}}},
            'm_1': {'kafka': {'message': {'topic': 'testing', 'channel': 'red'}}}}

to

{'events': {'webhook': {'url': 'http://www.example.com', 'action': 'merge'},
            'kafka': {'topic': 'testing', 'channel': 'red'}}