### PR TITLE
Added flake8 config setting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
 
 [flake8]
-extend-exclude = docs
+extend-exclude = docs, venv, .venv
 # show-source = True
 # Flake8 default ignore list:
 # ['W504', 'B904', 'B901', 'E24', 'W503', 'B950', 'E123', 'E704', 'B903', 'E121', 'B902', 'E226', 'E126']


### PR DESCRIPTION
When we run flake8 locally we want to be able to skip
the venv and .venv directories.