### PR TITLE
Raise exception if a playbook fails execution

### DIFF
--- a/ansible_events/builtin.py
+++ b/ansible_events/builtin.py
@@ -132,6 +132,7 @@ async def run_playbook(
     var_root: Optional[str] = None,
     copy_files: Optional[bool] = False,
     json_mode: Optional[bool] = False,
+    ignore_errors: Optional[bool] = False,
     **kwargs,
 ):
     logger = logging.getLogger()
@@ -213,6 +214,11 @@ async def run_playbook(
     ):
         with open(status_file, "r") as f:
             status = f.read()
+
+    if rc != 0 and not ignore_errors:
+        raise Exception(
+            f"Playbook {name} failed execution rc:{rc} status:{status}"
+        )
 
     if assert_facts or post_events:
         logger.debug("assert_facts")

--- a/ansible_events/builtin.py
+++ b/ansible_events/builtin.py
@@ -23,7 +23,7 @@ else:
 
 from .collection import find_playbook, has_playbook, split_collection_name
 from .conf import settings
-from .exception import ShutdownException
+from .exception import PlaybookFailureException, ShutdownException
 from .util import get_horizontal_rule
 
 
@@ -216,7 +216,7 @@ async def run_playbook(
             status = f.read()
 
     if rc != 0 and not ignore_errors:
-        raise Exception(
+        raise PlaybookFailureException(
             f"Playbook {name} failed execution rc:{rc} status:{status}"
         )
 

--- a/ansible_events/engine.py
+++ b/ansible_events/engine.py
@@ -21,7 +21,10 @@ from ansible_events.collection import (
     split_collection_name,
 )
 from ansible_events.durability import provide_durability
-from ansible_events.exception import ShutdownException
+from ansible_events.exception import (
+    PlaybookFailureException,
+    ShutdownException,
+)
 from ansible_events.messages import Shutdown
 from ansible_events.rule_types import (
     ActionContext,
@@ -212,6 +215,9 @@ async def call_action(
             result = dict(error=e)
         except ShutdownException:
             raise
+        except PlaybookFailureException as e:
+            logger.error(e)
+            result = dict(error=e)
         except Exception as e:
             logger.error(
                 f"Error calling {action}: {e}\n {traceback.format_exc()}"

--- a/ansible_events/exception.py
+++ b/ansible_events/exception.py
@@ -1,3 +1,8 @@
 class ShutdownException(Exception):
 
     pass
+
+
+class PlaybookFailureException(Exception):
+
+    pass

--- a/schema/ruleset_schema.json
+++ b/schema/ruleset_schema.json
@@ -103,7 +103,8 @@
                         "assert_facts": { "type": "boolean" },
                         "verbosity": {"type": "integer" },
                         "var_root": {"type": "string" },
-                        "json_mode": { "type": "boolean" }
+                        "json_mode": { "type": "boolean" },
+                        "ignore_errors": { "type": "boolean" }
                     },
                     "required": [
                         "name"

--- a/tests/playbooks/fail_playbook.yml
+++ b/tests/playbooks/fail_playbook.yml
@@ -1,0 +1,9 @@
+---
+- name: A playbook that always fails
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name:
+      ansible.builtin.fail:
+        msg: 'Intentionally failing test'
+      when: 1 != 0

--- a/tests/rules/test_host_rules.yml
+++ b/tests/rules/test_host_rules.yml
@@ -17,7 +17,7 @@
       condition: event.i == 2
       action:
         run_playbook:
-          name: playbooks/hello_world_set_fact.yml
+          name: playbooks/hello_events.yml
     - name:
       condition: event.i == 3
       action:

--- a/tests/rules/test_rules_exception_playbook.yml
+++ b/tests/rules/test_rules_exception_playbook.yml
@@ -1,0 +1,13 @@
+---
+- name: raise exception after running a playbook fails
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name:
+      condition: event.i == 1
+      action:
+        run_playbook:
+          name: playbooks/fail_playbook.yml

--- a/tests/rules/test_rules_fail_playbook.yml
+++ b/tests/rules/test_rules_fail_playbook.yml
@@ -1,0 +1,14 @@
+---
+- name: fail running a playbook
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name:
+      condition: event.i == 1
+      action:
+        run_playbook:
+          name: playbooks/fail_playbook.yml
+          ignore_errors: True


### PR DESCRIPTION
1. A user can supress the exception by setting ignore_errors
2. Fixed tests where the playbook was failing during execution
3. Added tests for ignore_errors

Replaces #123