### PR TITLE
Drools Support: Alternative execution flow via `jpy`

### DIFF
--- a/ansible_events/drools/durable_rules_engine.py
+++ b/ansible_events/drools/durable_rules_engine.py
@@ -1,114 +1,7 @@
-import json
 import logging
 import os
 
-import requests
-
 _logger = logging.getLogger(__name__)
-
-
-class DurableRulesEngine:
-    def __init__(self, host):
-        self._host = host
-        self._last_response = None
-
-    def create_ruleset(self, ruleset_name, ruleset_string):
-        request = {ruleset_name: json.loads(ruleset_string)}
-
-        response = requests.post(
-            self._host + "/create-durable-rules-executor", json=request
-        )
-        if response.status_code != 200:
-            raise Exception(
-                "Invalid status code: "
-                f"{response.status_code} - {response.reason}\n"
-                + json.loads(response.content)["details"]
-            )
-
-        return response.text
-
-    def assert_event(self, session_id, serialized_fact):
-        return self._process_message(
-            session_id, serialized_fact, "process-events"
-        )
-
-    def assert_fact(self, session_id, serialized_fact):
-        return self._process_message(
-            session_id, serialized_fact, "process-facts"
-        )
-
-    def _process_message(self, session_id, serialized_fact, command):
-        if command not in ["process-events", "process-facts"]:
-            raise Exception("Unknown command " + command)
-
-        fact = json.loads(serialized_fact)
-        if "j" in serialized_fact:
-            fact["j"] = 1
-
-        serialized_fact = json.dumps(fact)
-
-        response = requests.post(
-            f"{self._host}/rules-durable-executors/{session_id}/{command}",
-            json=json.loads(serialized_fact),
-        )
-
-        if response.status_code != 200:
-            raise Exception(
-                "Invalid status code: "
-                f"{response.status_code} - {response.reason}\n"
-                + json.loads(response.content)["details"]
-            )
-
-        self._last_response = response.json()
-        # drools returns the list in the opposite order
-        self._last_response.reverse()
-
-        return (0, session_id)
-
-    def start_action_for_state(self, handle):  # real signature unknown
-
-        if self._last_response:
-            resp = self._last_response.pop()
-        else:
-            return None
-
-        return ('{ "sid":"0", "id":"sid-0", "$s":1}', json.dumps(resp), handle)
-
-    def complete_and_start_action(self, handle):  # real signature unknown
-        _logger.info("complete_and_start_action: %s", handle)
-
-        if self._last_response:
-            resp = self._last_response.pop()
-        else:
-            return None
-
-        return json.dumps(resp)
-
-    def retract_fact(self, session_id, serialized_fact):
-        response = requests.post(
-            f"{self._host}/rules-durable-executors/{session_id}/retract-fact",
-            json=json.loads(serialized_fact),
-        )
-        if response.status_code != 200:
-            raise Exception(
-                "Invalid status code: "
-                f"{response.status_code} - {response.reason}\n"
-                + json.loads(response.content)["details"]
-            )
-
-        return (0, session_id)
-
-    def get_facts(self, session_id, _sid):
-        r = requests.post(
-            f"{self._host}/rules-durable-executors/{session_id}/get-all-facts"
-        )
-        if r.status_code != 200:
-            raise Exception(
-                f"Invalid status code: {r.status_code} - {r.reason}\n"
-                + json.loads(r.content)["details"]
-            )
-
-        return r.content
 
 
 class error(Exception):
@@ -122,10 +15,27 @@ class error(Exception):
     """list of weak references to the object (if defined)"""
 
 
+def make_instance():
+    jpy_classpath = os.environ.get("ANSIBLE_EVENTS_DROOLS_JPY_CLASSPATH")
+    if jpy_classpath:
+        from ansible_events.drools.jpy_durable_rules_engine import (
+            JpyDurableRulesEngine,
+        )
+
+        return JpyDurableRulesEngine(jpy_classpath)
+
+    from ansible_events.drools.rest_durable_rules_engine import (
+        RestDurableRulesEngine,
+    )
+
+    return RestDurableRulesEngine(
+        os.environ.get("ANSIBLE_EVENTS_DROOLS_HOST", "http://localhost:8080")
+    )
+
+
 # exported methods
-_instance = DurableRulesEngine(
-    os.environ.get("ANSIBLE_EVENTS_DROOLS_HOST", "http://localhost:8080")
-)
+
+_instance = make_instance()
 
 
 def abandon_action(*args, **kwargs):  # real signature unknown

--- a/ansible_events/drools/jpy_durable_rules_engine.py
+++ b/ansible_events/drools/jpy_durable_rules_engine.py
@@ -53,9 +53,6 @@ class JpyDurableRulesEngine:
 
     def _process_message(self, session_id, serialized_fact, command):
         fact = json.loads(serialized_fact)
-        if "j" in serialized_fact:
-            fact["j"] = 1
-
         serialized_fact = json.dumps(fact)
 
         result = command(serialized_fact)

--- a/ansible_events/drools/jpy_durable_rules_engine.py
+++ b/ansible_events/drools/jpy_durable_rules_engine.py
@@ -52,9 +52,6 @@ class JpyDurableRulesEngine:
         return self._process_message(session_id, serialized_fact, command)
 
     def _process_message(self, session_id, serialized_fact, command):
-        fact = json.loads(serialized_fact)
-        serialized_fact = json.dumps(fact)
-
         result = command(serialized_fact)
 
         self._last_response = json.loads(

--- a/ansible_events/drools/jpy_durable_rules_engine.py
+++ b/ansible_events/drools/jpy_durable_rules_engine.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 import jpy
@@ -14,78 +13,32 @@ class JpyDurableRulesEngine:
 
         jpyutil.init_jvm(jvm_maxmem="512M", jvm_classpath=classpath)
 
-        self._executor_class = jpy.get_type(
-            "org.drools.yaml.core.RulesExecutor"
+        JpyDurableRulesEngine_JavaAPI = jpy.get_type(
+            "org.drools.yaml.durable.jpy.JpyDurableRulesEngine"
         )
-        self._durable_rule_match_class = jpy.get_type(
-            "org.drools.yaml.durable.domain.DurableRuleMatch"
-        )
-        self._durable_notation = jpy.get_type(
-            "org.drools.yaml.durable.DurableNotation"
-        ).INSTANCE
-
-        self._executor_container = jpy.get_type(
-            "org.drools.yaml.core.RulesExecutorContainer"
-        ).INSTANCE
-        self._last_response = None
+        self._api = JpyDurableRulesEngine_JavaAPI()
 
     def create_ruleset(self, ruleset_name, ruleset_string):
-        payload = {ruleset_name: json.loads(ruleset_string)}
-        s = json.dumps(payload)
-        executor = self._executor_class.createFromJson(
-            self._durable_notation, s
-        )
-        return executor.getId()
+        return self._api.createRuleset(ruleset_name, ruleset_string)
 
     def assert_event(self, session_id, serialized_fact):
-        def command(fact):
-            executor = self._executor_container.get(session_id)
-            return executor.processEvents(fact)
-
-        return self._process_message(session_id, serialized_fact, command)
+        return (self._api.assertEvent(session_id, serialized_fact), session_id)
 
     def assert_fact(self, session_id, serialized_fact):
-        def command(fact):
-            executor = self._executor_container.get(session_id)
-            return executor.processFacts(fact)
+        return (self._api.assertFact(session_id, serialized_fact), session_id)
 
-        return self._process_message(session_id, serialized_fact, command)
-
-    def _process_message(self, session_id, serialized_fact, command):
-        result = command(serialized_fact)
-
-        self._last_response = json.loads(
-            self._durable_rule_match_class.asJson(result)
-        )
-        # drools returns the list in the opposite order
-        self._last_response.reverse()
-
-        return (0, session_id)
-
-    def start_action_for_state(self, handle):  # real signature unknown
-
-        if self._last_response:
-            resp = self._last_response.pop()
-        else:
+    def start_action_for_state(self, handle):
+        resp = self._api.advanceState()
+        if resp is None:
             return None
-
-        return ('{ "sid":"0", "id":"sid-0", "$s":1}', json.dumps(resp), handle)
+        return ('{ "sid":"0", "id":"sid-0", "$s":1}', resp, handle)
 
     def complete_and_start_action(self, handle):  # real signature unknown
-        _logger.info("complete_and_start_action: %s", handle)
-
-        if self._last_response:
-            resp = self._last_response.pop()
-        else:
-            return None
-
-        return json.dumps(resp)
+        resp = self._api.advanceState()
+        return resp
 
     def retract_fact(self, session_id, serialized_fact):
-        executor = self._executor_container.get(session_id)
-        executor.retract(serialized_fact)  # ignore bool return value for now
-        return (0, session_id)
+        return (self._api.retractFact(session_id, serialized_fact), session_id)
 
     def get_facts(self, session_id, _sid):
-        executor = self._executor_container.get(session_id)
-        return executor.getAllFactsAsJson()
+        return self._api.getFacts(session_id)

--- a/ansible_events/drools/jpy_durable_rules_engine.py
+++ b/ansible_events/drools/jpy_durable_rules_engine.py
@@ -1,0 +1,97 @@
+import json
+import logging
+
+import jpy
+import jpyutil
+
+_logger = logging.getLogger(__name__)
+
+
+class JpyDurableRulesEngine:
+    def __init__(self, classpath):
+        if not isinstance(classpath, list):
+            classpath = [classpath]
+
+        jpyutil.init_jvm(jvm_maxmem="512M", jvm_classpath=classpath)
+
+        self._executor_class = jpy.get_type(
+            "org.drools.yaml.core.RulesExecutor"
+        )
+        self._durable_rule_match_class = jpy.get_type(
+            "org.drools.yaml.durable.domain.DurableRuleMatch"
+        )
+        self._durable_notation = jpy.get_type(
+            "org.drools.yaml.durable.DurableNotation"
+        ).INSTANCE
+
+        self._executor_container = jpy.get_type(
+            "org.drools.yaml.core.RulesExecutorContainer"
+        ).INSTANCE
+        self._last_response = None
+
+    def create_ruleset(self, ruleset_name, ruleset_string):
+        payload = {ruleset_name: json.loads(ruleset_string)}
+        s = json.dumps(payload)
+        executor = self._executor_class.createFromJson(
+            self._durable_notation, s
+        )
+        return executor.getId()
+
+    def assert_event(self, session_id, serialized_fact):
+        def command(fact):
+            executor = self._executor_container.get(session_id)
+            return executor.processEvents(fact)
+
+        return self._process_message(session_id, serialized_fact, command)
+
+    def assert_fact(self, session_id, serialized_fact):
+        def command(fact):
+            executor = self._executor_container.get(session_id)
+            return executor.processFacts(fact)
+
+        return self._process_message(session_id, serialized_fact, command)
+
+    def _process_message(self, session_id, serialized_fact, command):
+        fact = json.loads(serialized_fact)
+        if "j" in serialized_fact:
+            fact["j"] = 1
+
+        serialized_fact = json.dumps(fact)
+
+        result = command(serialized_fact)
+
+        self._last_response = json.loads(
+            self._durable_rule_match_class.asJson(result)
+        )
+        # drools returns the list in the opposite order
+        self._last_response.reverse()
+
+        return (0, session_id)
+
+    def start_action_for_state(self, handle):  # real signature unknown
+
+        if self._last_response:
+            resp = self._last_response.pop()
+        else:
+            return None
+
+        return ('{ "sid":"0", "id":"sid-0", "$s":1}', json.dumps(resp), handle)
+
+    def complete_and_start_action(self, handle):  # real signature unknown
+        _logger.info("complete_and_start_action: %s", handle)
+
+        if self._last_response:
+            resp = self._last_response.pop()
+        else:
+            return None
+
+        return json.dumps(resp)
+
+    def retract_fact(self, session_id, serialized_fact):
+        executor = self._executor_container.get(session_id)
+        executor.retract(serialized_fact)  # ignore bool return value for now
+        return (0, session_id)
+
+    def get_facts(self, session_id, _sid):
+        executor = self._executor_container.get(session_id)
+        return executor.getAllFactsAsJson()

--- a/ansible_events/drools/rest_durable_rules_engine.py
+++ b/ansible_events/drools/rest_durable_rules_engine.py
@@ -41,9 +41,6 @@ class RestDurableRulesEngine:
             raise Exception("Unknown command " + command)
 
         fact = json.loads(serialized_fact)
-        if "j" in serialized_fact:
-            fact["j"] = 1
-
         serialized_fact = json.dumps(fact)
 
         response = requests.post(

--- a/ansible_events/drools/rest_durable_rules_engine.py
+++ b/ansible_events/drools/rest_durable_rules_engine.py
@@ -1,0 +1,110 @@
+import json
+import logging
+
+import requests
+
+_logger = logging.getLogger(__name__)
+
+
+class RestDurableRulesEngine:
+    def __init__(self, host):
+        self._host = host
+        self._last_response = None
+
+    def create_ruleset(self, ruleset_name, ruleset_string):
+        request = {ruleset_name: json.loads(ruleset_string)}
+
+        response = requests.post(
+            self._host + "/create-durable-rules-executor", json=request
+        )
+        if response.status_code != 200:
+            raise Exception(
+                "Invalid status code: "
+                f"{response.status_code} - {response.reason}\n"
+                + json.loads(response.content)["details"]
+            )
+
+        return response.text
+
+    def assert_event(self, session_id, serialized_fact):
+        return self._process_message(
+            session_id, serialized_fact, "process-events"
+        )
+
+    def assert_fact(self, session_id, serialized_fact):
+        return self._process_message(
+            session_id, serialized_fact, "process-facts"
+        )
+
+    def _process_message(self, session_id, serialized_fact, command):
+        if command not in ["process-events", "process-facts"]:
+            raise Exception("Unknown command " + command)
+
+        fact = json.loads(serialized_fact)
+        if "j" in serialized_fact:
+            fact["j"] = 1
+
+        serialized_fact = json.dumps(fact)
+
+        response = requests.post(
+            f"{self._host}/rules-durable-executors/{session_id}/{command}",
+            json=json.loads(serialized_fact),
+        )
+
+        if response.status_code != 200:
+            raise Exception(
+                "Invalid status code: "
+                f"{response.status_code} - {response.reason}\n"
+                + json.loads(response.content)["details"]
+            )
+
+        self._last_response = response.json()
+        # drools returns the list in the opposite order
+        self._last_response.reverse()
+
+        return (0, session_id)
+
+    def start_action_for_state(self, handle):  # real signature unknown
+
+        if self._last_response:
+            resp = self._last_response.pop()
+        else:
+            return None
+
+        return ('{ "sid":"0", "id":"sid-0", "$s":1}', json.dumps(resp), handle)
+
+    def complete_and_start_action(self, handle):  # real signature unknown
+        _logger.info("complete_and_start_action: %s", handle)
+
+        if self._last_response:
+            resp = self._last_response.pop()
+        else:
+            return None
+
+        return json.dumps(resp)
+
+    def retract_fact(self, session_id, serialized_fact):
+        response = requests.post(
+            f"{self._host}/rules-durable-executors/{session_id}/retract-fact",
+            json=json.loads(serialized_fact),
+        )
+        if response.status_code != 200:
+            raise Exception(
+                "Invalid status code: "
+                f"{response.status_code} - {response.reason}\n"
+                + json.loads(response.content)["details"]
+            )
+
+        return (0, session_id)
+
+    def get_facts(self, session_id, _sid):
+        r = requests.post(
+            f"{self._host}/rules-durable-executors/{session_id}/get-all-facts"
+        )
+        if r.status_code != 200:
+            raise Exception(
+                f"Invalid status code: {r.status_code} - {r.reason}\n"
+                + json.loads(r.content)["details"]
+            )
+
+        return r.content


### PR DESCRIPTION
Refactored `durable_rules_engine.py`:
- Moved rest-related code to `rest_durable_rules_engine.py`
- Added jpy-related code to `rest_durable_rules_engine.py`

The alternative backend can be conditionally activated by setting the following environment variables:

```
RULES_ENGINE=drools
ANSIBLE_EVENTS_DROOLS_JPY_CLASSPATH=<path-to-jar>
```

~~I had to expose some additional methods in the Java layer. We'll probably want to further iterate over this as we are now invoking some APIs that are not meant for external consumption.~~

EDIT I have just merged 5e5d8b743278c3ecfd62c103910039c1c4058f02 to hide the internals, but this depends on https://github.com/mariofusco/drools-yaml-rules/commit/d94c1240afd84945bfad06d1170f84f906b173d5 -- you should find the jar here https://github.com/mariofusco/drools-yaml-rules/actions/runs/2883890765

EDIT @mariofusco just [released a stable jar](https://github.com/mariofusco/drools-yaml-rules/releases/tag/v0.1) and you can now curl it from 
https://github.com/mariofusco/drools-yaml-rules/releases/download/v0.1/drools-yaml-rules-durable-rest-1.0.0-SNAPSHOT-runner.jar 
