### PR TITLE
improve jinja support and fix AAP-5176

### DIFF
--- a/ansible_events/util.py
+++ b/ansible_events/util.py
@@ -2,7 +2,6 @@ import os
 from pprint import pprint
 from typing import Any, Dict, List, Union
 
-import dpath.util
 import jinja2
 import yaml
 
@@ -22,10 +21,7 @@ def render_string(value: str, context: Dict) -> str:
 
 def render_string_or_return_value(value: Any, context: Dict) -> Any:
     if isinstance(value, str):
-        if value.startswith("{{") and value.endswith("}}"):
-            return dpath.util.get(context, value[2:-2], separator=".")
-        else:
-            return render_string(value, context)
+        return render_string(value, context)
     return value
 
 

--- a/tests/examples/28_right_side_condition_template.yml
+++ b/tests/examples/28_right_side_condition_template.yml
@@ -1,0 +1,12 @@
+---
+- name: 28 test jinja templating on the right side of the condition
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name:
+      condition: event.i == "{{ custom.expected_index }}"
+      action:
+        debug:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -713,3 +713,31 @@ async def test_27_var_root():
     event = event_log.get_nowait()
     assert event["type"] == "Shutdown", "7"
     assert event_log.empty()
+
+
+@pytest.mark.asyncio
+async def test_28_right_side_condition_template():
+    ruleset_queues, queue, event_log = load_rules(
+        "examples/28_right_side_condition_template.yml"
+    )
+
+    queue.put_nowait({"i": 1})
+    queue.put_nowait({"i": 2})
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        {"custom": {"expected_index": 2}},
+        dict(),
+    )
+
+    event_log.get_nowait()
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "debug", "2"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "1"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "7"
+    assert event_log.empty()


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAP-5176

There is no need to use dpath since jinja render can get the data from dicts with dot notation. In this way we add real support to jinja templates in the right side on the condition including jinja filters and arithmetic operations. 