### PR TITLE
downgrade docker image to ubi8 and add collection dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-39
+FROM registry.access.redhat.com/ubi8/python-39
 
 ARG USER_ID=${USER_ID:-1001}
 WORKDIR $HOME
@@ -8,7 +8,13 @@ RUN pip install -U pip \
     && pip install ansible \
     ansible-runner \
     jmespath \
+    asyncio \
+    aiohttp \
+    aiokafka \
+    watchdog \
+    azure-servicebus \
     && ansible-galaxy collection install benthomasson.eda
+
 COPY . $WORKDIR
 RUN chown -R $USER_ID ./
 


### PR DESCRIPTION
Seems that ubi9 image is not compatible with apple M1 processors. 
https://access.redhat.com/solutions/6833751
https://developers.redhat.com/blog/2021/01/05/building-red-hat-enterprise-linux-9-for-the-x86-64-v2-microarchitecture-level#

As ubi8 still have support, we can use it until have a fixed ubi9 image. 

Also added missing dependencies required by the collection