### PR TITLE
[AAP-5084] Add support for executing ansible modules as part of action

### DIFF
--- a/ansible_events/builtin.py
+++ b/ansible_events/builtin.py
@@ -204,7 +204,7 @@ async def run_module(
         for k, v in module_args.items():
             if len(module_args_str) > 0:
                 module_args_str += " "
-            module_args_str += f"{k}={v}"
+            module_args_str += f'{k}="{v}"'
 
     await call_runner(
         event_log,

--- a/tests/examples/29_run_module.yml
+++ b/tests/examples/29_run_module.yml
@@ -1,0 +1,22 @@
+---
+- name: 29 run module
+  hosts: all
+  sources:
+    - range:
+        limit: 5
+  rules:
+    - name:
+      condition: event.i == 1
+      action:
+        run_module:
+          name: benthomasson.eda.upcase
+          module_args:
+              name: fred
+
+
+
+
+
+
+
+

--- a/tests/examples/29_run_module.yml
+++ b/tests/examples/29_run_module.yml
@@ -11,7 +11,7 @@
         run_module:
           name: benthomasson.eda.upcase
           module_args:
-              name: fred
+              name: Fred Flintstone
 
 
 

--- a/tests/examples/30_run_module_missing.yml
+++ b/tests/examples/30_run_module_missing.yml
@@ -1,0 +1,22 @@
+---
+- name: 30 run module missing
+  hosts: all
+  sources:
+    - range:
+        limit: 5
+  rules:
+    - name:
+      condition: event.i == 1
+      action:
+        run_module:
+          name: benthomasson.eda.upcase2
+          module_args:
+              name: fred
+
+
+
+
+
+
+
+

--- a/tests/examples/31_run_module_missing_args.yml
+++ b/tests/examples/31_run_module_missing_args.yml
@@ -1,0 +1,22 @@
+---
+- name: 31 run module missing args
+  hosts: all
+  sources:
+    - range:
+        limit: 5
+  rules:
+    - name:
+      condition: event.i == 1
+      action:
+        run_module:
+          name: benthomasson.eda.upcase
+          module_args:
+              un_name: fred
+
+
+
+
+
+
+
+

--- a/tests/examples/32_run_module_fail.yml
+++ b/tests/examples/32_run_module_fail.yml
@@ -1,0 +1,22 @@
+---
+- name: 32 run module fail
+  hosts: all
+  sources:
+    - range:
+        limit: 5
+  rules:
+    - name:
+      condition: event.i == 1
+      action:
+        run_module:
+          name: benthomasson.eda.upcase
+          module_args:
+              name: fail
+
+
+
+
+
+
+
+

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -741,3 +741,137 @@ async def test_28_right_side_condition_template():
     event = event_log.get_nowait()
     assert event["type"] == "Shutdown", "7"
     assert event_log.empty()
+
+
+@pytest.mark.asyncio
+async def test_29_run_module():
+    ruleset_queues, queue, event_log = load_rules("examples/29_run_module.yml")
+
+    queue.put_nowait(dict(i=1, meta=dict(hosts="localhost")))
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        dict(),
+    )
+
+    event = event_log.get_nowait()
+    assert event["type"] == "Job", "0"
+    for i in range(4):
+        assert event_log.get_nowait()["type"] == "AnsibleEvent", f"0.{i}"
+
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "run_module", "2"
+
+    assert event["rc"] == 0, "2.1"
+    assert event["status"] == "successful", "2.2"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "7"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "8"
+    assert event_log.empty()
+
+
+@pytest.mark.asyncio
+async def test_30_run_module_missing():
+    ruleset_queues, queue, event_log = load_rules(
+        "examples/30_run_module_missing.yml"
+    )
+
+    queue.put_nowait(dict(i=1, meta=dict(hosts="localhost")))
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        dict(),
+    )
+
+    event = event_log.get_nowait()
+    assert event["type"] == "Job", "0"
+    for i in range(4):
+        assert event_log.get_nowait()["type"] == "AnsibleEvent", f"0.{i}"
+
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "run_module", "2"
+
+    assert event["rc"] == 2, "2.1"
+    assert event["status"] == "failed", "2.2"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "7"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "8"
+    assert event_log.empty()
+
+
+@pytest.mark.asyncio
+async def test_31_run_module_missing_args():
+    ruleset_queues, queue, event_log = load_rules(
+        "examples/31_run_module_missing_args.yml"
+    )
+
+    queue.put_nowait(dict(i=1, meta=dict(hosts="localhost")))
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        dict(),
+    )
+
+    event = event_log.get_nowait()
+    assert event["type"] == "Job", "0"
+    for i in range(4):
+        assert event_log.get_nowait()["type"] == "AnsibleEvent", f"0.{i}"
+
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "run_module", "2"
+
+    assert event["rc"] == 2, "2.1"
+    assert event["status"] == "failed", "2.2"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "7"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "8"
+    assert event_log.empty()
+
+
+@pytest.mark.asyncio
+async def test_32_run_module_fail():
+    ruleset_queues, queue, event_log = load_rules(
+        "examples/32_run_module_fail.yml"
+    )
+
+    queue.put_nowait(dict(i=1, meta=dict(hosts="localhost")))
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        dict(),
+    )
+
+    event = event_log.get_nowait()
+    assert event["type"] == "Job", "0"
+    for i in range(4):
+        assert event_log.get_nowait()["type"] == "AnsibleEvent", f"0.{i}"
+
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "run_module", "2"
+
+    assert event["rc"] == 2, "2.1"
+    assert event["status"] == "failed", "2.2"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "7"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "8"
+    assert event_log.empty()


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-5084

- Modules can only be part of collection
- Module args can be passed in via module_args

e.g.
```
action:
        run_module:
          name: ansible.builtin.debug
          module_args:
              msg: fred
```