### PR TITLE
[AAP-5126] Allow to rerun a playbook on failure

### DIFF
--- a/ansible_events/builtin.py
+++ b/ansible_events/builtin.py
@@ -134,6 +134,9 @@ async def run_playbook(
     var_root: Union[str, Dict, None] = None,
     copy_files: Optional[bool] = False,
     json_mode: Optional[bool] = False,
+    retries: Optional[int] = 0,
+    retry: Optional[bool] = False,
+    delay: Optional[int] = 0,
     **kwargs,
 ):
     logger = logging.getLogger()
@@ -152,15 +155,24 @@ async def run_playbook(
         **kwargs,
     )
     logger.info("Calling Ansible runner")
-    await call_runner(
-        event_log,
-        job_id,
-        temp,
-        dict(playbook=playbook_name),
-        hosts,
-        verbosity,
-        json_mode,
-    )
+
+    if retry:
+        retries = max(retries, 1)
+    for i in range(retries + 1):
+        if i > 0 and delay > 0:
+            await asyncio.sleep(delay)
+        await call_runner(
+            event_log,
+            job_id,
+            temp,
+            dict(playbook=playbook_name),
+            hosts,
+            verbosity,
+            json_mode,
+        )
+        if get_status(temp) != "failed":
+            break
+
     await post_process_runner(
         event_log, temp, ruleset, "run_playbook", assert_facts, post_events
     )
@@ -181,6 +193,9 @@ async def run_module(
     copy_files: Optional[bool] = False,
     json_mode: Optional[bool] = False,
     module_args: Union[Dict, None] = None,
+    retries: Optional[int] = 0,
+    retry: Optional[bool] = False,
+    delay: Optional[int] = 0,
     **kwargs,
 ):
     logger = logging.getLogger()
@@ -206,19 +221,27 @@ async def run_module(
                 module_args_str += " "
             module_args_str += f'{k}="{v}"'
 
-    await call_runner(
-        event_log,
-        job_id,
-        temp,
-        dict(
-            module=module_name,
-            host_pattern=",".join(hosts),
-            module_args=module_args_str,
-        ),
-        hosts,
-        verbosity,
-        json_mode,
-    )
+    if retry:
+        retries = max(retries, 1)
+    for i in range(retries + 1):
+        if i > 0 and delay > 0:
+            await asyncio.sleep(delay)
+        await call_runner(
+            event_log,
+            job_id,
+            temp,
+            dict(
+                module=module_name,
+                host_pattern=",".join(hosts),
+                module_args=module_args_str,
+            ),
+            hosts,
+            verbosity,
+            json_mode,
+        )
+        if get_status(temp) != "failed":
+            break
+
     await post_process_runner(
         event_log, temp, ruleset, "run_module", assert_facts, post_events
     )
@@ -343,11 +366,7 @@ async def post_process_runner(
         with open(rc_file, "r") as f:
             rc = int(f.read())
 
-    for status_file in glob.glob(
-        os.path.join(private_data_dir, "artifacts", "*", "status")
-    ):
-        with open(status_file, "r") as f:
-            status = f.read()
+    status = get_status(private_data_dir)
 
     if assert_facts or post_events:
         logger.debug("assert_facts")
@@ -361,6 +380,7 @@ async def post_process_runner(
                 lang.assert_fact(ruleset, fact)
             if post_events:
                 lang.post(ruleset, fact)
+
     await event_log.put(
         dict(type="Action", action=action, rc=rc, status=status)
     )
@@ -410,3 +430,13 @@ def update_variables(variables: Dict, var_root: Union[str, Dict]):
                 if new_value:
                     variables["events"][new_key] = new_value
                     break
+
+
+def get_status(private_data_dir: str):
+    status_files = glob.glob(
+        os.path.join(private_data_dir, "artifacts", "*", "status")
+    )
+    status_files.sort(key=os.path.getmtime, reverse=True)
+    with open(status_files[0], "r") as f:
+        status = f.read()
+    return status

--- a/schema/ruleset_schema.json
+++ b/schema/ruleset_schema.json
@@ -103,7 +103,10 @@
                         "assert_facts": { "type": "boolean" },
                         "verbosity": {"type": "integer" },
                         "var_root": {"type": "string" },
-                        "json_mode": { "type": "boolean" }
+                        "json_mode": { "type": "boolean" },
+                        "retry": { "type": "boolean" },
+                        "retries": { "type": "integer" },
+                        "delay": { "type": "integer" }
                     },
                     "required": [
                         "name"

--- a/tests/examples/33_run_playbook_retry.yml
+++ b/tests/examples/33_run_playbook_retry.yml
@@ -1,5 +1,5 @@
 ---
-- name: 32 run module fail
+- name: 33 run playbook and retry after an interval
   hosts: all
   sources:
     - range:
@@ -8,8 +8,7 @@
     - name:
       condition: event.i == 1
       action:
-        run_module:
-          name: benthomasson.eda.upcase
-          module_args:
-              name: fail
+        run_playbook:
+          name: playbooks/fail_and_succeed.yml
           retry: True
+          delay: 1

--- a/tests/examples/34_run_playbook_retries.yml
+++ b/tests/examples/34_run_playbook_retries.yml
@@ -1,0 +1,13 @@
+---
+- name: 34 run playbook and retry a number of times
+  hosts: all
+  sources:
+    - range:
+        limit: 5
+  rules:
+    - name:
+      condition: event.i == 1
+      action:
+        run_playbook:
+          name: playbooks/fail_and_succeed.yml
+          retries: 1

--- a/tests/playbooks/fail_and_succeed.yml
+++ b/tests/playbooks/fail_and_succeed.yml
@@ -1,0 +1,31 @@
+---
+- name: Playbook to fail the first run and succeed the second run
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Define a temp file
+      ansible.builtin.set_fact:
+        my_path: "/tmp/ansible_event-fail_and_succeed"
+
+    - name: Check that the temp file exists
+      ansible.builtin.stat:
+        path: "{{ my_path }}"
+      register: my_file
+      
+
+    - name: Create the file
+      ansible.builtin.file:
+        path: "{{ my_path }}"
+        state: touch
+      when: not my_file.stat.exists
+
+    - name: Fail if the file does not exist
+      ansible.builtin.fail:
+        msg: "Failing because the test file does not exist"
+      when: not my_file.stat.exists
+
+    - name: Delete the file
+      ansible.builtin.file:
+        path: "{{ my_path }}"
+        state: absent
+      when: my_file.stat.exists

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -537,11 +537,17 @@ async def test_20_is_not_defined():
     assert event_log.empty()
 
 
+PLAYBOOK_RULES = [
+    "examples/21_run_playbook.yml",
+    "examples/33_run_playbook_retry.yml",
+    "examples/34_run_playbook_retries.yml",
+]
+
+
 @pytest.mark.asyncio
-async def test_21_run_playbook():
-    ruleset_queues, queue, event_log = load_rules(
-        "examples/21_run_playbook.yml"
-    )
+@pytest.mark.parametrize("rule", PLAYBOOK_RULES)
+async def test_21_run_playbook(rule):
+    ruleset_queues, queue, event_log = load_rules(rule)
 
     queue.put_nowait(dict(i=1))
     queue.put_nowait(Shutdown())
@@ -861,7 +867,7 @@ async def test_32_run_module_fail():
 
     event = event_log.get_nowait()
     assert event["type"] == "Job", "0"
-    for i in range(4):
+    for i in range(8):
         assert event_log.get_nowait()["type"] == "AnsibleEvent", f"0.{i}"
 
     event = event_log.get_nowait()


### PR DESCRIPTION
Add option `retry: True` to rerun a playbook once on failure,
or `retries: <count>` to retry multiple times until succeed.
Option `delay: <seconds>` to pause a few seconds before rerun.

The same options can be applied to rerun a module.

See tests/examples/33_run_playbook_retry.yml or
tests/examples/34_run_playbook_retries.yml or
tests/examples/32_run_module_fail.yml for examples.

Resolves: AAP-5126