### PR TITLE
Check if the exception value is None before logging it as error

### DIFF
--- a/ansible_events/app.py
+++ b/ansible_events/app.py
@@ -71,7 +71,7 @@ async def run(parsed_args) -> None:
         task.cancel()
     exceptions = await asyncio.gather(*tasks, return_exceptions=True)
     for exception in exceptions:
-        if not isinstance(exception, CancelledError):
+        if exception and not isinstance(exception, CancelledError):
             logger.error(exception)
 
     logger.info("Main complete")


### PR DESCRIPTION
When a co-routine exists and it doesn't return anything, the gather function returns None. We assume the returned values are exceptions and log None as an error.
Fixed the code to check if the returned value is None before checking its exception type

Fixes #155 